### PR TITLE
Fix compatibility with ElasticSearch 0.90.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -27,7 +27,7 @@
 	</parent>
 
 	<properties>
-		<elasticsearch.version>0.19.3</elasticsearch.version>
+		<elasticsearch.version>0.90.0</elasticsearch.version>
 	</properties>
 
 	<repositories>
@@ -48,7 +48,7 @@
 		<dependency>
 			<groupId>org.carrot2</groupId>
 			<artifactId>morfologik-polish</artifactId>
-			<version>1.5.3</version>
+			<version>1.6.0</version>
 		</dependency>
 
 		<dependency>

--- a/src/main/java/org/apache/lucene/analysis/morfologik/MorfologikAnalyzer.java
+++ b/src/main/java/org/apache/lucene/analysis/morfologik/MorfologikAnalyzer.java
@@ -23,7 +23,7 @@ import java.io.Reader;
 import org.apache.lucene.analysis.Tokenizer;
 import org.apache.lucene.analysis.standard.StandardFilter;
 import org.apache.lucene.analysis.standard.StandardTokenizer;
-import org.apache.lucene.analysis.ReusableAnalyzerBase;
+import org.apache.lucene.analysis.Analyzer;
 import org.apache.lucene.util.Version;
 
 import morfologik.stemming.PolishStemmer.DICTIONARY;
@@ -32,7 +32,7 @@ import morfologik.stemming.PolishStemmer.DICTIONARY;
  * {@link org.apache.lucene.analysis.Analyzer} using Morfologik library.
  * @see <a href="http://morfologik.blogspot.com/">Morfologik project page</a>
  */
-public class MorfologikAnalyzer extends ReusableAnalyzerBase {
+public class MorfologikAnalyzer extends Analyzer {
 
   private final DICTIONARY dictionary;
   private final Version version;

--- a/src/main/java/org/apache/lucene/analysis/morfologik/MorfologikFilter.java
+++ b/src/main/java/org/apache/lucene/analysis/morfologik/MorfologikFilter.java
@@ -29,7 +29,7 @@ import org.apache.lucene.analysis.TokenFilter;
 import org.apache.lucene.analysis.TokenStream;
 import org.apache.lucene.analysis.tokenattributes.CharTermAttribute;
 import org.apache.lucene.analysis.tokenattributes.PositionIncrementAttribute;
-import org.apache.lucene.util.CharacterUtils;
+import org.apache.lucene.analysis.util.CharacterUtils;
 import org.apache.lucene.util.CharsRef;
 import org.apache.lucene.util.Version;
 


### PR DESCRIPTION
The commit fixes issue #2. Analyzer and filter tested successfully with Elastic Search 0.90.0, morfologik-stemming upgraded to 1.6.0.
