### PR TITLE
Remove references to morfologik.stemming.PolishStemmer.DICTIONARY

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 	<artifactId>elasticsearch-analysis-morfologik</artifactId>
 	<packaging>jar</packaging>
 	<name>elasticsearch-analysis-morfologik</name>
-	<version>2.0.1-SNAPSHOT</version>
+	<version>2.1</version>
 	<description>Morfologik (Polish) Analysis for ElasticSearch</description>
 	<licenses>
 		<license>
@@ -15,9 +15,9 @@
 		</license>
 	</licenses>
 	<scm>
-		<connection>scm:git:git@github.com:chytreg/elasticsearch-analysis-morfologik.git</connection>
-		<developerConnection>scm:git:git@github.com:chytreg/elasticsearch-analysis-morfologik.git</developerConnection>
-		<url>https://github.com/chytreg/elasticsearch-analysis-morfologik</url>
+		<connection>scm:git:git@github.com:ee/elasticsearch-analysis-morfologik.git</connection>
+		<developerConnection>scm:git:git@github.com:ee/elasticsearch-analysis-morfologik.git</developerConnection>
+		<url>https://github.com/ee/elasticsearch-analysis-morfologik</url>
 	</scm>
 
 	<parent>
@@ -27,7 +27,7 @@
 	</parent>
 
 	<properties>
-		<elasticsearch.version>0.90.0</elasticsearch.version>
+		<elasticsearch.version>1.1.0</elasticsearch.version>
 	</properties>
 
 	<repositories>
@@ -48,7 +48,7 @@
 		<dependency>
 			<groupId>org.carrot2</groupId>
 			<artifactId>morfologik-polish</artifactId>
-			<version>1.6.0</version>
+			<version>1.9.0</version>
 		</dependency>
 
 		<dependency>

--- a/src/main/java/org/apache/lucene/analysis/morfologik/MorfologikAnalyzer.java
+++ b/src/main/java/org/apache/lucene/analysis/morfologik/MorfologikAnalyzer.java
@@ -26,30 +26,13 @@ import org.apache.lucene.analysis.standard.StandardTokenizer;
 import org.apache.lucene.analysis.Analyzer;
 import org.apache.lucene.util.Version;
 
-import morfologik.stemming.PolishStemmer.DICTIONARY;
-
 /**
  * {@link org.apache.lucene.analysis.Analyzer} using Morfologik library.
  * @see <a href="http://morfologik.blogspot.com/">Morfologik project page</a>
  */
 public class MorfologikAnalyzer extends Analyzer {
 
-  private final DICTIONARY dictionary;
   private final Version version;
-
-  /**
-   * Builds an analyzer for a given PolishStemmer.DICTIONARY enum.
-   *
-   * @param vers
-   *          lucene compatibility version
-   * @param dict
-   *          A constant specifying which dictionary to choose. See the
-   *          Morfologik documentation for details or use the default.
-   */
-  public MorfologikAnalyzer(final Version vers, final DICTIONARY dict) {
-    this.version = vers;
-    this.dictionary = dict;
-  }
 
   /**
    * Builds an analyzer for an original MORFOLOGIK dictionary.
@@ -57,7 +40,7 @@ public class MorfologikAnalyzer extends Analyzer {
    * @param vers         lucene compatibility version
    */
   public MorfologikAnalyzer(final Version vers) {
-    this(vers, DICTIONARY.MORFOLOGIK);
+    this.version = vers;
   }
 
   /**
@@ -79,6 +62,6 @@ public class MorfologikAnalyzer extends Analyzer {
 
     return new TokenStreamComponents(
       src,
-      new MorfologikFilter(new StandardFilter(this.version, src), this.dictionary, this.version));
+      new MorfologikFilter(new StandardFilter(this.version, src), this.version));
   }
 }

--- a/src/main/java/org/apache/lucene/analysis/morfologik/MorfologikFilter.java
+++ b/src/main/java/org/apache/lucene/analysis/morfologik/MorfologikFilter.java
@@ -23,7 +23,6 @@ import java.util.Collections;
 import java.util.List;
 
 import morfologik.stemming.*;
-import morfologik.stemming.PolishStemmer.DICTIONARY;
 
 import org.apache.lucene.analysis.TokenFilter;
 import org.apache.lucene.analysis.TokenStream;
@@ -61,13 +60,12 @@ public class MorfologikFilter extends TokenFilter {
    * Builds a filter for given PolishStemmer.DICTIONARY enum.
    *
    * @param in   input token stream
-   * @param dict PolishStemmer.DICTIONARY enum
    * @param version Lucene version compatibility for lowercasing.
    */
-  public MorfologikFilter(final TokenStream in, final DICTIONARY dict, final Version version) {
+  public MorfologikFilter(final TokenStream in, final Version version) {
     super(in);
     this.input = in;
-    this.stemmer = new PolishStemmer(dict);
+    this.stemmer = new PolishStemmer();
     this.charUtils = CharacterUtils.getInstance(version);
     this.lemmaList = Collections.emptyList();
   }

--- a/src/main/java/org/elasticsearch/index/analysis/pl/MorfologikAnalyzerProvider.java
+++ b/src/main/java/org/elasticsearch/index/analysis/pl/MorfologikAnalyzerProvider.java
@@ -20,7 +20,6 @@
 package org.elasticsearch.index.analysis.pl;
 
 import morfologik.stemming.*;
-import morfologik.stemming.PolishStemmer.DICTIONARY;
 import org.apache.lucene.analysis.TokenStream;
 import org.apache.lucene.analysis.morfologik.*;
 
@@ -44,7 +43,7 @@ public class MorfologikAnalyzerProvider extends AbstractIndexAnalyzerProvider<Mo
     @Inject
     public MorfologikAnalyzerProvider(Index index, @IndexSettings Settings indexSettings, Environment env, @Assisted String name, @Assisted Settings settings) {
         super(index, indexSettings, name, settings);
-        analyzer = new MorfologikAnalyzer(version, PolishStemmer.DICTIONARY.COMBINED);
+        analyzer = new MorfologikAnalyzer(version);
     }
 
     @Override

--- a/src/main/java/org/elasticsearch/index/analysis/pl/MorfologikStemTokenFilterFactory.java
+++ b/src/main/java/org/elasticsearch/index/analysis/pl/MorfologikStemTokenFilterFactory.java
@@ -20,7 +20,6 @@
 package org.elasticsearch.index.analysis.pl;
 
 import morfologik.stemming.*;
-import morfologik.stemming.PolishStemmer.DICTIONARY;
 import org.apache.lucene.analysis.TokenStream;
 import org.apache.lucene.analysis.morfologik.*;
 
@@ -43,6 +42,6 @@ public class MorfologikStemTokenFilterFactory extends AbstractTokenFilterFactory
     }
 
     @Override public TokenStream create(TokenStream tokenStream) {
-        return new MorfologikFilter(tokenStream, PolishStemmer.DICTIONARY.COMBINED, version);
+        return new MorfologikFilter(tokenStream, version);
     }
 }

--- a/src/main/java/org/elasticsearch/indices/analysis/pl/MorfologikIndicesAnalysis.java
+++ b/src/main/java/org/elasticsearch/indices/analysis/pl/MorfologikIndicesAnalysis.java
@@ -30,7 +30,6 @@ import org.elasticsearch.indices.analysis.IndicesAnalysisService;
 import org.elasticsearch.index.analysis.TokenFilterFactory;
 
 import morfologik.stemming.*;
-import morfologik.stemming.PolishStemmer.DICTIONARY;
 import org.apache.lucene.analysis.TokenStream;
 import org.apache.lucene.analysis.morfologik.*;
 
@@ -52,7 +51,7 @@ public class MorfologikIndicesAnalysis extends AbstractComponent {
             }
 
             @Override public TokenStream create(TokenStream tokenStream) {
-                return new MorfologikFilter(tokenStream, PolishStemmer.DICTIONARY.COMBINED, Lucene.ANALYZER_VERSION);
+                return new MorfologikFilter(tokenStream, Lucene.ANALYZER_VERSION);
             }
         }));
     }


### PR DESCRIPTION
Now I'm able to compile it and use with ES 1.1. Solves #4 for me. Credits go to Krzysztof Sobolewski.
